### PR TITLE
feat: added slo duplicates check during validate

### DIFF
--- a/cmd/sloth/commands/validate.go
+++ b/cmd/sloth/commands/validate.go
@@ -27,6 +27,7 @@ type validateCommand struct {
 	sliPluginsPaths      []string
 	sloPeriodWindowsPath string
 	sloPeriod            string
+	ignoreSloDuplicates  bool
 }
 
 // NewValidateCommand returns the validate command.
@@ -40,7 +41,7 @@ func NewValidateCommand(app *kingpin.Application) Command {
 	cmd.Flag("sli-plugins-path", "The path to SLI plugins (can be repeated), if not set it disable plugins support.").Short('p').StringsVar(&c.sliPluginsPaths)
 	cmd.Flag("slo-period-windows-path", "The directory path to custom SLO period windows catalog (replaces default ones).").StringVar(&c.sloPeriodWindowsPath)
 	cmd.Flag("default-slo-period", "The default SLO period windows to be used for the SLOs.").Default("30d").StringVar(&c.sloPeriod)
-
+	cmd.Flag("ignore-slo-duplicates", "Flag to ignore SLO duplicates in specs (service and name used as an SLO/SLI identifier).").Default("false").BoolVar(&c.ignoreSloDuplicates)
 	return c
 }
 
@@ -115,6 +116,7 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 	// For every file load the data and start the validation process:
 	validations := []*fileValidation{}
 	totalValidations := 0
+	sloIDs := make(map[string]string, 0)
 	for _, input := range sloPaths {
 		// Get SLO spec data.
 		slxData, err := os.ReadFile(input)
@@ -142,11 +144,21 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			// Match the spec type to know how to validate.
 			switch {
 			case promYAMLLoader.IsSpecType(ctx, dataB):
-				slos, promErr := promYAMLLoader.LoadSpec(ctx, dataB)
+				sloGroup, promErr := promYAMLLoader.LoadSpec(ctx, dataB)
 				if promErr == nil {
-					err := gen.GeneratePrometheus(ctx, *slos, io.Discard)
+					if !v.ignoreSloDuplicates {
+						for _, slo := range sloGroup.SLOs {
+							if sloFile, exists := sloIDs[slo.ID]; !exists {
+								sloIDs[slo.ID] = validation.File
+							} else {
+								validation.Errs = append(validation.Errs, fmt.Errorf("SLO duplicated. SLO{service=%s, name=%s}, ID=%s already exists in a file: %s", slo.Service, slo.Name, slo.ID, sloFile))
+							}
+						}
+					}
+
+					err := gen.GeneratePrometheus(ctx, *sloGroup, io.Discard)
 					if err != nil {
-						validation.Errs = []error{fmt.Errorf("Could not generate Prometheus format rules: %w", err)}
+						validation.Errs = append(validation.Errs, fmt.Errorf("Could not generate Prometheus format rules: %w", err))
 					}
 					continue
 				}
@@ -156,9 +168,19 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			case kubeYAMLLoader.IsSpecType(ctx, dataB):
 				sloGroup, k8sErr := kubeYAMLLoader.LoadSpec(ctx, dataB)
 				if k8sErr == nil {
+					if !v.ignoreSloDuplicates {
+						for _, slo := range sloGroup.SLOs {
+							if sloFile, exists := sloIDs[slo.ID]; !exists {
+								sloIDs[slo.ID] = validation.File
+							} else {
+								validation.Errs = append(validation.Errs, fmt.Errorf("SLO duplicated. SLO{service=%s, name=%s}, ID=%s already exists in a file: %s", slo.Service, slo.Name, slo.ID, sloFile))
+							}
+						}
+					}
+
 					err := gen.GenerateKubernetes(ctx, *sloGroup, io.Discard)
 					if err != nil {
-						validation.Errs = []error{fmt.Errorf("could not generate Kubernetes format rules: %w", err)}
+						validation.Errs = append(validation.Errs, fmt.Errorf("could not generate Kubernetes format rules: %w", err)}
 					}
 					continue
 				}
@@ -166,11 +188,21 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 				validation.Errs = []error{fmt.Errorf("Tried loading Kubernetes prometheus SLOs spec, it couldn't: %w", k8sErr)}
 
 			case openSLOYAMLLoader.IsSpecType(ctx, dataB):
-				slos, openSLOErr := openSLOYAMLLoader.LoadSpec(ctx, dataB)
+				sloGroup, openSLOErr := openSLOYAMLLoader.LoadSpec(ctx, dataB)
 				if openSLOErr == nil {
-					err := gen.GenerateOpenSLO(ctx, *slos, io.Discard)
+					if !v.ignoreSloDuplicates {
+						for _, slo := range sloGroup.SLOs {
+							if sloFile, exists := sloIDs[slo.ID]; !exists {
+								sloIDs[slo.ID] = validation.File
+							} else {
+								validation.Errs = append(validation.Errs, fmt.Errorf("SLO duplicated. SLO{service=%s, name=%s}, ID=%s already exists in a file: %s", slo.Service, slo.Name, slo.ID, sloFile))
+							}
+						}
+					}
+
+					err := gen.GenerateOpenSLO(ctx, *sloGroup, io.Discard)
 					if err != nil {
-						validation.Errs = []error{fmt.Errorf("Could not generate OpenSLO format rules: %w", err)}
+						validation.Errs = append(validation.Errs, fmt.Errorf("Could not generate OpenSLO format rules: %w", err)}
 					}
 					continue
 				}

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml
@@ -1,0 +1,87 @@
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true
+
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1" # duplicate
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02" # duplicate
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-duplicate.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-original.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-duplicate.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-original.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-duplicate.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-original.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/validate_test.go
+++ b/test/integration/prometheus/validate_test.go
@@ -48,6 +48,22 @@ func TestPrometheusValidate(t *testing.T) {
 		"Discovery of all specs excluding bad and including a bad one should validate correctly because exclude has preference.": {
 			valCmdArgs: "--input ./testdata/validate --fs-exclude bad --fs-include .*-aa.*",
 		},
+
+		"Discovery of bad Prom specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/prom",
+		},
+
+		"Discovery of bad K8S specs with duplicates k8s validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/prom",
+		},
+
+		"Discovery of bad K8S specs with duplicates OpenSlo validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/openslo",
+		},
+
+		"Discovery of bad Prom multifile specs with duplicates validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
I've noticed that if I pass a folder to sloth validate it allows SLO duplicates to exist.

When creating a new SLO sometemes I copy spec from existing specs and forgot to change names.
Sloth perfectly validates and generates rules in such cases. But it can lead to duplicates of recording rules, and unpredictable behaviour durind recording.

We can deploy rules as prom, k8s, and openslo. Prom and K8S are almost the same and have equal slo_id format <service>-<slo.name>, but OpenSLO uses slightly different <service>-<slo.name>-<seq_no>.

So it looks like better not to mix spec types for the same service.
But if I have a folder with specs of one type, e.g. Prom specs for CLI generation, I want to know about slo duplicates in a folder or multifile yml.

Issue #493