### PR TITLE
feat: added slo duplicates check during validate (#1)

### DIFF
--- a/test/integration/prometheus/testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml
@@ -1,0 +1,87 @@
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true
+
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1" # duplicate
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02" # duplicate
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-duplicate.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/k8s/bad-k8s-1-original.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-duplicate.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/openslo/bad-openslo-1-original.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-duplicate.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/duplicates/prom/bad-prom-1-original.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/validate_test.go
+++ b/test/integration/prometheus/validate_test.go
@@ -48,6 +48,22 @@ func TestPrometheusValidate(t *testing.T) {
 		"Discovery of all specs excluding bad and including a bad one should validate correctly because exclude has preference.": {
 			valCmdArgs: "--input ./testdata/validate --fs-exclude bad --fs-include .*-aa.*",
 		},
+
+		"Discovery of bad Prom specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/prom",
+		},
+
+		"Discovery of bad K8S specs with duplicates k8s validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/prom",
+		},
+
+		"Discovery of bad K8S specs with duplicates OpenSlo validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/openslo",
+		},
+
+		"Discovery of bad Prom multifile specs with duplicates validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate/bad/duplicates/bad-prom-multi-duplicates.yaml",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Add checks for SLO duplicates into sloth validate command.
Enabled by default.
To disable use --ignore-slo-duplicates=true param.

Issue https://github.com/slok/sloth/issues/493