### PR TITLE
Added duplicates check (for sloth 0v.15+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ vendor/
 
 # mise/asdf
 .tool-versions
+
+# VSCode
+.vscode/

--- a/cmd/sloth/commands/validate.go
+++ b/cmd/sloth/commands/validate.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/slok/sloth/internal/log"
 	"github.com/slok/sloth/internal/plugin"
+	commonerrors "github.com/slok/sloth/pkg/common/errors"
 	utilsdata "github.com/slok/sloth/pkg/common/utils/data"
 	slothlib "github.com/slok/sloth/pkg/lib"
 )
@@ -28,6 +29,7 @@ type validateCommand struct {
 	sloPeriod                string
 	sloPlugins               []string
 	disableDefaultSLOPlugins bool
+	ignoreSloDuplicates      bool
 }
 
 // NewValidateCommand returns the validate command.
@@ -43,6 +45,7 @@ func NewValidateCommand(app *kingpin.Application) Command {
 	cmd.Flag("default-slo-period", "The default SLO period windows to be used for the SLOs.").Default("30d").StringVar(&c.sloPeriod)
 	cmd.Flag("slo-plugins", `SLO plugins chain declaration in JSON format '{"id": "foo","priority": 0,"config": "{}"}' (Can be repeated).`).Short('s').StringsVar(&c.sloPlugins)
 	cmd.Flag("disable-default-slo-plugins", `Disables the default SLO plugins, normally used along with custom SLO plugins to fully customize Sloth behavior`).BoolVar(&c.disableDefaultSLOPlugins)
+	cmd.Flag("ignore-slo-duplicates", "Flag to ignore SLO duplicates in specs (service and name used as an SLO/SLI identifier).").Default("false").BoolVar(&c.ignoreSloDuplicates)
 
 	return c
 }
@@ -117,6 +120,7 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 	// For every file load the data and start the validation process:
 	validations := []*fileValidation{}
 	totalValidations := 0
+	sloIDs := make(map[string]string)
 	for _, input := range sloPaths {
 		// Get SLO spec data.
 		slxData, err := os.ReadFile(input)
@@ -140,9 +144,25 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			}
 
 			// Generate SLOs.
-			_, err := genService.GenerateFromRaw(ctx, []byte(genTarget.SLOData))
+			sloGroupResult, err := genService.GenerateFromRaw(ctx, []byte(genTarget.SLOData))
 			if err != nil {
 				validation.Errs = append(validation.Errs, fmt.Errorf("invalid SLO: %w", err))
+			} else {
+				// Check for SLO duplicates
+				if !v.ignoreSloDuplicates {
+					for _, sloResult := range sloGroupResult.SLOResults {
+						slo := sloResult.SLO
+						if sloFile, exists := sloIDs[slo.ID]; !exists {
+							sloIDs[slo.ID] = validation.File
+						} else {
+							err := fmt.Errorf(
+								"SLO duplicated. SLO{service=%s, name=%s}, ID=%s already exists in a file: %s: %w",
+								slo.Service, slo.Name, slo.ID, sloFile, commonerrors.ErrAlreadyExists,
+							)
+							validation.Errs = append(validation.Errs, err)
+						}
+					}
+				}
 			}
 		}
 

--- a/pkg/common/errors/errors.go
+++ b/pkg/common/errors/errors.go
@@ -12,4 +12,7 @@ var (
 
 	// ErrRequired will be used when a required field is not set.
 	ErrRequired = fmt.Errorf("required")
+
+	// ErrAlreadyExists will be used when a resource already exists.
+	ErrAlreadyExists = fmt.Errorf("already exists")
 )

--- a/test/integration/prometheus/testdata/validate_with_duplicates/bad-prom-multi-duplicates.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/bad-prom-multi-duplicates.yaml
@@ -1,0 +1,87 @@
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true
+
+---
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1" # duplicate
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02" # duplicate
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate_with_duplicates/k8s/bad-k8s-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/k8s/bad-k8s-1-duplicate.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate_with_duplicates/k8s/bad-k8s-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/k8s/bad-k8s-1-original.yaml
@@ -1,0 +1,47 @@
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  service: "svc01"
+  labels:
+    global01k1: global01v1
+  slos:
+    - name: "slo1"
+      objective: 99.9
+      description: "This is SLO 01."
+      labels:
+        global02k1: global02v1
+      sli:
+        events:
+          errorQuery: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          totalQuery: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: myServiceAlert
+        labels:
+          alert01k1: "alert01v1"
+        annotations:
+          alert02k1: "alert02k2"
+        pageAlert:
+          labels:
+            alert03k1: "alert03v1"
+        ticketAlert:
+          labels:
+            alert04k1: "alert04v1"
+    - name: "slo02"
+      objective: 95
+      description: "This is SLO 02."
+      labels:
+        global03k1: global03v1
+      sli:
+        raw:
+          errorRatioQuery: |
+            sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+            /
+            sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        pageAlert:
+          disable: true
+        ticketAlert:
+          disable: true

--- a/test/integration/prometheus/testdata/validate_with_duplicates/openslo/bad-openslo-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/openslo/bad-openslo-1-duplicate.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate_with_duplicates/openslo/bad-openslo-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/openslo/bad-openslo-1-original.yaml
@@ -1,0 +1,23 @@
+apiVersion: openslo/v1alpha
+kind: SLO
+metadata:
+  name: slo1
+  displayName: Integration test SLO1
+spec:
+  service: svc01
+  description: "this is SLO1."
+  budgetingMethod: Occurrences
+  objectives:
+    - ratioMetrics:
+        good:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
+        total:
+          source: prometheus
+          queryType: promql
+          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      target: 0.999
+  timeWindows:
+    - count: 30
+      unit: Day

--- a/test/integration/prometheus/testdata/validate_with_duplicates/prom/bad-prom-1-duplicate.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/prom/bad-prom-1-duplicate.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/testdata/validate_with_duplicates/prom/bad-prom-1-original.yaml
+++ b/test/integration/prometheus/testdata/validate_with_duplicates/prom/bad-prom-1-original.yaml
@@ -1,0 +1,42 @@
+version: "prometheus/v1"
+service: "svc01"
+labels:
+  global01k1: global01v1
+slos:
+  - name: "slo1"
+    objective: 99.9
+    description: "This is SLO 01."
+    labels:
+      global02k1: global02v1
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: myServiceAlert
+      labels:
+        alert01k1: "alert01v1"
+      annotations:
+        alert02k1: "alert02k2"
+      pageAlert:
+        labels:
+          alert03k1: "alert03v1"
+      ticketAlert:
+        labels:
+          alert04k1: "alert04v1"
+  - name: "slo02"
+    objective: 95
+    description: "This is SLO 02."
+    labels:
+      global03k1: global03v1
+    sli:
+      raw:
+        error_ratio_query: |
+          sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      page_alert:
+        disable: true
+      ticket_alert:
+        disable: true

--- a/test/integration/prometheus/validate_test.go
+++ b/test/integration/prometheus/validate_test.go
@@ -19,7 +19,7 @@ func TestPrometheusValidate(t *testing.T) {
 		expErr     bool
 	}{
 		"Discovery of good specs should validate correctly.": {
-			valCmdArgs: "--input ./testdata/validate/good",
+			valCmdArgs: "--input ./testdata/validate/good --ignore-slo-duplicates",
 		},
 
 		"Discovery of bad specs should validate with failures.": {
@@ -33,11 +33,11 @@ func TestPrometheusValidate(t *testing.T) {
 		},
 
 		"Discovery of all specs excluding bads should validate correctly.": {
-			valCmdArgs: "--input ./testdata/validate --fs-exclude bad",
+			valCmdArgs: "--input ./testdata/validate --fs-exclude bad --ignore-slo-duplicates",
 		},
 
 		"Discovery of all specs including only good should validate correctly.": {
-			valCmdArgs: "--input ./testdata/validate --fs-include good",
+			valCmdArgs: "--input ./testdata/validate --fs-include good --ignore-slo-duplicates",
 		},
 
 		"Discovery of none specs should fail.": {
@@ -46,7 +46,37 @@ func TestPrometheusValidate(t *testing.T) {
 		},
 
 		"Discovery of all specs excluding bad and including a bad one should validate correctly because exclude has preference.": {
-			valCmdArgs: "--input ./testdata/validate --fs-exclude bad --fs-include .*-aa.*",
+			valCmdArgs: "--input ./testdata/validate --fs-exclude bad --fs-include .*-aa.* --ignore-slo-duplicates",
+		},
+
+		"Discovery of specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates",
+			expErr:     true,
+		},
+
+		"Discovery of specs with duplicates and ignore flag should validate correctly.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates --ignore-slo-duplicates",
+			expErr:     false,
+		},
+
+		"Discovery of prom specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates/prom",
+			expErr:     true,
+		},
+
+		"Discovery of k8s specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates/k8s",
+			expErr:     true,
+		},
+
+		"Discovery of openslo specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates/openslo",
+			expErr:     true,
+		},
+
+		"Discovery of multi-file prom specs with duplicates should validate with failures.": {
+			valCmdArgs: "--input ./testdata/validate_with_duplicates/bad-prom-multi-duplicates.yaml",
+			expErr:     true,
 		},
 	}
 


### PR DESCRIPTION
It adds checks for SLO duplicates into sloth validate command.
Enabled by default.
To disable use --ignore-slo-duplicates=true param.

This feature was completely rewritten as sloth 0.12 code has many backward-incompatible changes. It was easier to rewrite it than resolving all the conflicts.

Related to https://github.com/slok/sloth/issues/493